### PR TITLE
Google Cloud DNS plugin

### DIFF
--- a/engine/conf/tornado.conf.tpl
+++ b/engine/conf/tornado.conf.tpl
@@ -81,6 +81,10 @@
 	    # EBS disk template snapshot id
 	    "ebs_template": None,
 
+	# For google cloud DNS
+	"project": "jc-test1",
+	"zone": "juliaenterprise"
+
     	"dummy" : "dummy"
     },
 
@@ -134,6 +138,7 @@ Welcome to JuliaBox. We hope you will like it and also share with your friends.
         "juliabox.plugins.sendmail_ses",
         "juliabox.plugins.api_admin",
         "juliabox.plugins.user_admin",
+	"juliabox.plugins.dns_gcloud",
         ""
     ],
 

--- a/engine/src/juliabox/cloud/compute.py
+++ b/engine/src/juliabox/cloud/compute.py
@@ -55,6 +55,7 @@ class JBPluginCloud(LoggerMixin):
 
     JBP_DNS = "cloud.dns"
     JBP_DNS_ROUTE53 = "cloud.dns.route53"
+    JBP_DNS_GCLOUD = "cloud.dns.gcloud"
 
     JBP_SENDMAIL = "cloud.sendmail"
     JBP_SENDMAIL_SES = "cloud.sendmail.ses"

--- a/engine/src/juliabox/plugins/dns_gcloud/__init__.py
+++ b/engine/src/juliabox/plugins/dns_gcloud/__init__.py
@@ -1,0 +1,3 @@
+__author__ = 'Nishanth'
+
+from impl_gcloud import JBoxGCloudDNS

--- a/engine/src/juliabox/plugins/dns_gcloud/impl_gcloud.py
+++ b/engine/src/juliabox/plugins/dns_gcloud/impl_gcloud.py
@@ -1,0 +1,69 @@
+__author__ = 'Nishanth'
+
+
+from juliabox.cloud import JBPluginCloud
+from juliabox.jbox_util import JBoxCfg
+from googleapiclient.discovery import build
+from oauth2client.client import GoogleCredentials
+
+
+class JBoxGCloudDNS(JBPluginCloud):
+    provides = [JBPluginCloud.JBP_DNS, JBPluginCloud.JBP_DNS_GCLOUD]
+
+    PROJECT = None
+    ZONE = None
+    CONN = None
+
+    @staticmethod
+    def configure():
+        cloud_host = JBoxCfg.get('cloud_host')
+        JBoxGCloudDNS.PROJECT = cloud_host['project'] # project name in google dns
+        JBoxGCloudDNS.ZONE = cloud_host['zone'] # zone name in google dns
+
+    @staticmethod
+    def domain():
+        if JBoxGCloudDNS.PROJECT is None:
+            JBoxGCloudDNS.configure()
+        return JBoxGCloudDNS.PROJECT
+
+    @staticmethod
+    def connect():
+        if JBoxGCloudDNS.CONN is None:
+            JBoxGCloudDNS.configure()
+            # should run `gcloud auth login` to have this default
+            creds = GoogleCredentials.get_application_default()
+            JBoxGCloudDNS.CONN = build('dns', 'v1', credentials=creds)
+        return JBoxGCloudDNS.CONN
+
+    @staticmethod
+    def add_cname(name, value):
+        JBoxGCloudDNS.connect().changes().create(
+            project=JBoxGCloudDNS.PROJECT, managedZone=JBoxGCloudDNS.ZONE,
+            body={"kind": "dns#change",
+                  "additions": [
+                      {"rrdatas": [value],
+                       "kind": "dns#resourceRecordSet",
+                       "type": "CNAME",
+                       "name": name,
+                       "ttl": 300}    ] }).execute()
+
+    @staticmethod
+    def delete_cname(name):
+        resp = JBoxGCloudDNS.connect().resourceRecordSets().list(
+            project=JBoxGCloudDNS.PROJECT, managedZone=JBoxGCloudDNS.ZONE,
+            name=name, type="CNAME").execute()
+        if len(resp["rrsets"]) == 0:
+            JBoxGCloudDNS.log_debug("No prior dns registration found for %s", name)
+        else:
+            cname = resp["rrsets"][0]["rrdatas"][0]
+            ttl = resp["ttl"]
+            JBoxGCloudDNS.connect().changes().create(
+                project=JBoxGCloudDNS.PROJECT, managedZone=JBoxGCloudDNS.ZONE,
+                body={"kind": "dns#change",
+                      "deletions": [
+                          {"rrdatas": [str(cname)],
+                           "kind": "dns#resourceRecordSet",
+                           "type": "CNAME",
+                           "name": name,
+                           "ttl": ttl}    ] }).execute()
+            JBoxGCloudDNS.log_warn("Prior dns registration was found for %s", name)

--- a/scripts/install/sys_install.sh
+++ b/scripts/install/sys_install.sh
@@ -20,6 +20,7 @@ function sysinstall_pystuff {
     sudo pip install sh
     sudo pip install pyzmq
     sudo pip install docker-py
+    sudo pip install oauth2client
 }
 
 function sysinstall_libs {


### PR DESCRIPTION
- Added a plugin `dns_gcloud` for Google cloud DNS service.
- Added install command for `oauth2client` in `sys_install.sh`.
- Added `project` and `zone` to `cloud_host` field in `tornado.conf.tpl`.  These are parameters needed by the google cloud dns service.
